### PR TITLE
Make credential subject id optional

### DIFF
--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -4,6 +4,9 @@
 
 ### Features
 
+- add TypeScript typings
+- make credential subject id optional
+
 ### Fixes
 
 ### Deprecations

--- a/src/datatypes.rs
+++ b/src/datatypes.rs
@@ -93,7 +93,8 @@ pub struct UnsignedCredential {
 #[derive(Serialize, Deserialize, Clone, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct CredentialSubject {
-    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
     pub data: HashMap<String, String>,
 }
 

--- a/src/vade_jwt_vc.rs
+++ b/src/vade_jwt_vc.rs
@@ -147,9 +147,9 @@ impl VadePlugin for VadeJwtVC {
                     &value,
                 )?;
                 if revoked {
-                    let verfication_result = ProofVerification { verified: false };
+                    let verification_result = ProofVerification { verified: false };
                     return Ok(VadePluginResultValue::Success(Some(serde_json::to_string(
-                        &verfication_result,
+                        &verification_result,
                     )?)));
                 }
             }

--- a/typings/application/datatypes.d.ts
+++ b/typings/application/datatypes.d.ts
@@ -85,7 +85,7 @@ export interface UnsignedCredential {
  * Payload/data part of a verifiable credential.
  */
 export interface CredentialSubject {
-  id: string;
+  id?: string;
   data: Record<string, string>;
 }
 


### PR DESCRIPTION
## Description

<!--- WHAT does this PR change/fix? -->
<!--- WHY is this change required? What problem does it solve? -->

Makes `id` property in credential subject optional to allow creating credentials without a predefined subject id.